### PR TITLE
Streaming audio hack in MentraOS transport

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,4 +21,6 @@ env/
 venv/
 .venv
 pip-log.txt
-pip-delete-this-directory.txt 
+pip-delete-this-directory.txt
+# Audio files
+audio-generation/ 

--- a/python/mentraos/pipecat/mp3_encoder.py
+++ b/python/mentraos/pipecat/mp3_encoder.py
@@ -1,0 +1,172 @@
+"""MP3 encoder for TTS audio streaming."""
+
+import os
+from pathlib import Path
+from datetime import datetime
+from typing import Optional
+import numpy as np
+
+try:
+    import lameenc
+except ImportError:
+    lameenc = None
+
+from loguru import logger
+
+
+class MP3StreamEncoder:
+    """Handles MP3 encoding for TTS audio streams."""
+    
+    def __init__(self, output_dir: str = "audio-generation"):
+        """Initialize MP3 encoder.
+        
+        Args:
+            output_dir: Directory to write audio files
+        """
+        self.output_dir = Path(output_dir)
+        self.output_dir.mkdir(exist_ok=True)
+        logger.info(f"🎵 MP3StreamEncoder initialized with output_dir: {self.output_dir.absolute()}")
+        
+        self.encoder: Optional[lameenc.Encoder] = None
+        self.current_file: Optional[Path] = None
+        self.file_handle = None
+        self.sample_rate: Optional[int] = None
+        self.num_channels: Optional[int] = None
+        
+        if lameenc is None:
+            logger.error("lameenc not installed - MP3 encoding will not work!")
+    
+    def start_new_stream(self, sample_rate: int, num_channels: int) -> Optional[str]:
+        """Start a new MP3 stream with a timestamped filename.
+        
+        Args:
+            sample_rate: Audio sample rate in Hz
+            num_channels: Number of audio channels
+            
+        Returns:
+            The filename stem (without extension) if successful, None otherwise
+        """
+        if lameenc is None:
+            logger.error("Cannot start MP3 stream - lameenc not installed")
+            return None
+            
+        try:
+            # Generate timestamp-based filename
+            timestamp = datetime.now().strftime("%Y%m%d_%H%M%S_%f")[:-3]  # Include milliseconds
+            filename_stem = f"tts_{timestamp}"
+            self.current_file = self.output_dir / f"{filename_stem}.generating"
+            
+            logger.info(f"🎵 Starting new MP3 stream: {self.current_file}")
+            
+            # Initialize encoder
+            self.encoder = lameenc.Encoder()
+            self.encoder.set_bit_rate(64)  # 64 kbps as per requirements
+            self.encoder.set_in_sample_rate(sample_rate)
+            self.encoder.set_channels(num_channels)
+            self.encoder.set_quality(2)  # High quality
+            
+            self.sample_rate = sample_rate
+            self.num_channels = num_channels
+            
+            # Open file for writing
+            self.file_handle = open(self.current_file, 'wb')
+            logger.info(f"📂 Opened file for writing: {self.current_file.absolute()}")
+            
+            return filename_stem
+            
+        except Exception as e:
+            logger.error(f"Failed to start MP3 stream: {e}")
+            self.cleanup()
+            return None
+    
+    def write_audio_chunk(self, audio_data: bytes) -> bool:
+        """Write audio chunk to the current stream.
+        
+        Args:
+            audio_data: Raw PCM audio bytes (16-bit signed)
+            
+        Returns:
+            True if successful, False otherwise
+        """
+        if not self.encoder or not self.file_handle:
+            logger.error("No active MP3 stream")
+            return False
+            
+        try:
+            # Ensure even number of bytes for 16-bit samples
+            if len(audio_data) % 2 != 0:
+                logger.warning(f"Odd number of audio bytes ({len(audio_data)}), truncating")
+                audio_data = audio_data[:-1]
+            
+            # Encode to MP3
+            mp3_data = self.encoder.encode(audio_data)
+            
+            if mp3_data:
+                self.file_handle.write(bytes(mp3_data))
+                self.file_handle.flush()  # Ensure data is written immediately
+                logger.info(f"✍️ Wrote {len(mp3_data)} MP3 bytes ({len(audio_data)} PCM bytes) to {self.current_file}")
+                return True
+            else:
+                logger.warning(f"⚠️ No MP3 data returned from encoder for {len(audio_data)} PCM bytes")
+            
+            return False
+            
+        except Exception as e:
+            logger.error(f"Failed to write audio chunk: {e}")
+            return False
+    
+    def finalize_stream(self) -> bool:
+        """Finalize the current stream and rename the file.
+        
+        Returns:
+            True if successful, False otherwise
+        """
+        if not self.encoder or not self.file_handle or not self.current_file:
+            logger.warning("No active stream to finalize")
+            return False
+            
+        try:
+            # Flush encoder
+            mp3_data = self.encoder.flush()
+            if mp3_data:
+                self.file_handle.write(bytes(mp3_data))
+                logger.debug(f"Wrote {len(mp3_data)} final MP3 bytes")
+            
+            # Close file
+            self.file_handle.close()
+            self.file_handle = None
+            
+            # Rename file to remove .generating extension
+            final_file = self.current_file.with_suffix('')  # Remove .generating
+            self.current_file.rename(final_file)
+            
+            logger.info(f"✅ Finalized MP3 stream: {final_file}")
+            
+            # Reset state
+            self.encoder = None
+            self.current_file = None
+            self.sample_rate = None
+            self.num_channels = None
+            logger.info("🔄 MP3 encoder state reset after finalization")
+            
+            return True
+            
+        except Exception as e:
+            logger.error(f"Failed to finalize stream: {e}")
+            self.cleanup()
+            return False
+    
+    def cleanup(self):
+        """Clean up resources without finalizing."""
+        try:
+            if self.file_handle:
+                self.file_handle.close()
+                self.file_handle = None
+            
+            self.encoder = None
+            self.current_file = None
+            self.sample_rate = None
+            self.num_channels = None
+            
+        except Exception as e:
+            logger.error(f"Error during cleanup: {e}")

--- a/python/mentraos/pipecat/mp3_encoder.py
+++ b/python/mentraos/pipecat/mp3_encoder.py
@@ -104,10 +104,9 @@ class MP3StreamEncoder:
             if mp3_data:
                 self.file_handle.write(bytes(mp3_data))
                 self.file_handle.flush()  # Ensure data is written immediately
-                logger.info(f"✍️ Wrote {len(mp3_data)} MP3 bytes ({len(audio_data)} PCM bytes) to {self.current_file}")
                 return True
             else:
-                logger.warning(f"⚠️ No MP3 data returned from encoder for {len(audio_data)} PCM bytes")
+                logger.debug(f"No MP3 data returned from encoder for {len(audio_data)} PCM bytes")
             
             return False
             
@@ -130,7 +129,6 @@ class MP3StreamEncoder:
             mp3_data = self.encoder.flush()
             if mp3_data:
                 self.file_handle.write(bytes(mp3_data))
-                logger.debug(f"Wrote {len(mp3_data)} final MP3 bytes")
             
             # Close file
             self.file_handle.close()
@@ -147,7 +145,7 @@ class MP3StreamEncoder:
             self.current_file = None
             self.sample_rate = None
             self.num_channels = None
-            logger.info("🔄 MP3 encoder state reset after finalization")
+            # MP3 encoder state reset after finalization
             
             return True
             

--- a/python/mentraos/pipecat/transport.py
+++ b/python/mentraos/pipecat/transport.py
@@ -104,7 +104,7 @@ class MentraOSInputTransport(BaseInputTransport):
 class MentraOSOutputTransport(BaseOutputTransport):
     """Output transport for sending frames to MentraOS."""
 
-    def __init__(self, transport: "MentraOSWebSocketTransport", params: TransportParams):
+    def __init__(self, transport: "MentraOSWebSocketTransport", params: TransportParams, bot_stopped_speaking_delay: float = 2.5):
         super().__init__(params)
         self._transport = transport
         # Use absolute path for audio generation directory
@@ -119,7 +119,7 @@ class MentraOSOutputTransport(BaseOutputTransport):
         self._total_audio_samples: int = 0
         self._audio_sample_rate: int = 24000  # Default, will be updated from frames
         self._silent_frames_task: Optional[asyncio.Task] = None
-        self._bot_stopped_speaking_delay = 2.5  # MentraOS audio startup delay
+        self._bot_stopped_speaking_delay = bot_stopped_speaking_delay  # MentraOS audio startup delay
         
         logger.info(f"🎵 MentraOSOutputTransport initialized with MP3 streaming (URL: {self._public_url})")
 
@@ -394,6 +394,7 @@ class MentraOSWebSocketTransport(BaseTransport):
         vad_analyzer: Optional[VADAnalyzer] = None,
         input_name: str | None = None,
         output_name: str | None = None,
+        bot_stopped_speaking_delay: float = 2.5,
     ):
         super().__init__(input_name=input_name, output_name=output_name)
 
@@ -403,6 +404,7 @@ class MentraOSWebSocketTransport(BaseTransport):
         self._package_name = package_name
         self._enable_transcription = enable_transcription
         self._app_session: Optional[AppSession] = None
+        self._bot_stopped_speaking_delay = bot_stopped_speaking_delay
 
         # Create transport params
         params = TransportParams(
@@ -412,7 +414,7 @@ class MentraOSWebSocketTransport(BaseTransport):
 
         # Create input/output transports
         self._input_transport = MentraOSInputTransport(self, params)
-        self._output_transport = MentraOSOutputTransport(self, params)
+        self._output_transport = MentraOSOutputTransport(self, params, bot_stopped_speaking_delay=bot_stopped_speaking_delay)
 
         # Tasks
         self._receive_task: Optional[asyncio.Task] = None

--- a/python/mentraos/pipecat/transport.py
+++ b/python/mentraos/pipecat/transport.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import os
+import time
 from typing import Optional, Callable
 from concurrent.futures import ThreadPoolExecutor
 
@@ -21,6 +22,8 @@ from pipecat.frames.frames import (
     TTSStartedFrame,
     TTSStoppedFrame,
     OutputAudioRawFrame,
+    BotStartedSpeakingFrame,
+    BotStoppedSpeakingFrame,
 )
 from dataclasses import dataclass
 from pipecat.processors.frame_processor import FrameDirection
@@ -111,6 +114,13 @@ class MentraOSOutputTransport(BaseOutputTransport):
         self._public_url = os.getenv("MENTRAOS_PUBLIC_URL", "https://khk-mentra.ngrok.app")
         self._tts_active = False  # Track if we're between TTSStartedFrame and TTSStoppedFrame
         
+        # Audio duration tracking for silent frame generation
+        self._audio_start_time: Optional[float] = None
+        self._total_audio_samples: int = 0
+        self._audio_sample_rate: int = 24000  # Default, will be updated from frames
+        self._silent_frames_task: Optional[asyncio.Task] = None
+        self._bot_stopped_speaking_delay = 2.5  # MentraOS audio startup delay
+        
         logger.info(f"🎵 MentraOSOutputTransport initialized with MP3 streaming (URL: {self._public_url})")
 
     async def start(self, frame: StartFrame):
@@ -131,6 +141,10 @@ class MentraOSOutputTransport(BaseOutputTransport):
         if not isinstance(frame, (InputAudioRawFrame, OutputAudioRawFrame)) or isinstance(frame, TTSAudioRawFrame):
             logger.debug(f"📊 MentraOSOutputTransport.process_frame: {type(frame).__name__}")
         
+        # Also log bot speaking frames
+        if isinstance(frame, (BotStartedSpeakingFrame, BotStoppedSpeakingFrame)):
+            logger.info(f"🤖 MentraOSOutputTransport.process_frame: {type(frame).__name__} (direction: {direction})")
+        
         # Handle TTS state tracking
         if isinstance(frame, TTSStartedFrame):
             logger.info("🎤 Received TTSStartedFrame - TTS is now active")
@@ -138,6 +152,31 @@ class MentraOSOutputTransport(BaseOutputTransport):
         elif isinstance(frame, TTSStoppedFrame):
             logger.info("🔇 Received TTSStoppedFrame - finalizing MP3 stream")
             self._tts_active = False
+            
+            # Calculate remaining playback time and start silent frames if needed
+            if self._audio_start_time and self._total_audio_samples > 0:
+                audio_duration = self._total_audio_samples / self._audio_sample_rate
+                elapsed_time = time.time() - self._audio_start_time
+                remaining_time = audio_duration - elapsed_time + 0.5  # Add 500ms buffer for network/playback delays
+                
+                # Add MentraOS audio startup delay
+                total_silent_duration = remaining_time + self._bot_stopped_speaking_delay
+                
+                logger.info(f"⏱️ Audio stats: Total duration={audio_duration:.3f}s, Elapsed={elapsed_time:.3f}s, Remaining={remaining_time:.3f}s")
+                logger.info(f"🎯 Adding {self._bot_stopped_speaking_delay}s MentraOS startup delay = {total_silent_duration:.3f}s total silent frames")
+                
+                if total_silent_duration > 0:
+                    # Cancel any existing silent frames task
+                    if self._silent_frames_task and not self._silent_frames_task.done():
+                        self._silent_frames_task.cancel()
+                        logger.debug("🚫 Cancelled existing silent frames task")
+                    
+                    # Start new silent frames task with the extended duration
+                    self._silent_frames_task = asyncio.create_task(self._send_silent_frames(total_silent_duration))
+                    logger.info(f"🔇 Started silent frames task for {total_silent_duration:.3f}s")
+                else:
+                    logger.info("⚡ Audio generation was slower than playback - no silent frames needed")
+            
             # Finalize the current MP3 stream
             if self._current_tts_filename:
                 if self._mp3_encoder.finalize_stream():
@@ -174,6 +213,11 @@ class MentraOSOutputTransport(BaseOutputTransport):
         # Reset TTS state
         self._tts_active = False
         
+        # Cancel silent frames task if running
+        if self._silent_frames_task and not self._silent_frames_task.done():
+            self._silent_frames_task.cancel()
+            logger.debug("🚫 Cancelled silent frames task on stop")
+        
         # Finalize any active MP3 stream
         if self._current_tts_filename:
             if self._mp3_encoder.finalize_stream():
@@ -191,11 +235,22 @@ class MentraOSOutputTransport(BaseOutputTransport):
         if isinstance(frame, TTSAudioRawFrame):
             # Only process TTS audio if we're between TTSStartedFrame and TTSStoppedFrame
             if not self._tts_active:
-                logger.warning(f"⚠️ Ignoring TTSAudioRawFrame - not between TTSStartedFrame and TTSStoppedFrame")
+                logger.warning(f"⚠️ Ignoring TTSAudioRawFrame - not between TTSStartedFrame and TTSStoppedFrame (tts_active={self._tts_active})")
                 return
             
-            logger.info(f"🔊 Processing TTSAudioRawFrame, current_filename: {self._current_tts_filename}")
+            logger.info(f"🔊 Processing TTSAudioRawFrame, current_filename: {self._current_tts_filename}, app_session: {self._transport._app_session is not None}")
             try:
+                # Track audio duration - start timing and reset samples when new stream starts
+                if not self._current_tts_filename:
+                    self._audio_start_time = time.time()
+                    self._total_audio_samples = 0
+                    self._audio_sample_rate = frame.sample_rate
+                    logger.info(f"⏱️ Starting audio duration tracking at {self._audio_start_time:.3f}, sample_rate={self._audio_sample_rate}")
+                
+                # Count samples in this frame (assuming 16-bit audio = 2 bytes per sample)
+                num_samples = len(frame.audio) // 2
+                self._total_audio_samples += num_samples
+                
                 # Start new stream if needed
                 if not self._current_tts_filename:
                     self._current_tts_filename = self._mp3_encoder.start_new_stream(
@@ -227,7 +282,9 @@ class MentraOSOutputTransport(BaseOutputTransport):
                 else:
                     # Write subsequent chunks
                     if self._mp3_encoder.write_audio_chunk(frame.audio):
-                        logger.debug(f"📝 Wrote audio chunk to {self._current_tts_filename}")
+                        elapsed = time.time() - self._audio_start_time
+                        duration_so_far = self._total_audio_samples / self._audio_sample_rate
+                        logger.debug(f"📝 Wrote audio chunk to {self._current_tts_filename} | Samples: {self._total_audio_samples} | Duration: {duration_so_far:.3f}s | Elapsed: {elapsed:.3f}s")
                     else:
                         logger.error(f"❌ Failed to write audio chunk")
                         
@@ -235,12 +292,65 @@ class MentraOSOutputTransport(BaseOutputTransport):
                 logger.error(f"❌ Error handling TTS audio: {e}")
         
         else:
-            logger.info(f"📤 Non-TTS audio frame, passing to transport: {type(frame).__name__}")
+            logger.info(f"📤 Non-TTS audio frame: {type(frame).__name__}")
         
-        # Don't send TTS audio to the actual transport
-        # For other audio types, call the parent method
-        if not isinstance(frame, TTSAudioRawFrame):
-            await self._transport.write_audio_frame(frame)
+        # Note: We do NOT forward frames from write_audio_frame - this is the final
+        # destination. The MediaSender tracks bot speaking state when it processes
+        # TTSAudioRawFrame frames through the audio task.
+    
+    async def _send_silent_frames(self, duration: float):
+        """Send silent audio frames to keep MediaSender active during audio playback."""
+        logger.info(f"🔇 Starting to send silent frames for {duration:.3f}s to maintain bot speaking state")
+        
+        # Send frames every 20ms (typical audio frame duration)
+        frame_duration = 0.02  # 20ms
+        num_frames = int(duration / frame_duration)
+        
+        # Create silent audio (480 samples at 24kHz = 20ms)
+        samples_per_frame = int(self._audio_sample_rate * frame_duration)
+        silent_audio = b'\x00' * (samples_per_frame * 2)  # 16-bit samples = 2 bytes per sample
+        
+        logger.debug(f"📊 Silent frame config: {num_frames} frames, {samples_per_frame} samples/frame, {len(silent_audio)} bytes/frame")
+        
+        start_time = time.time()
+        frames_sent = 0
+        
+        try:
+            for i in range(num_frames):
+                # Create silent OutputAudioRawFrame (not TTSAudioRawFrame!)
+                silent_frame = OutputAudioRawFrame(
+                    audio=silent_audio,
+                    sample_rate=self._audio_sample_rate,
+                    num_channels=1
+                )
+                
+                # Route through parent's process_frame to reach MediaSender
+                # This will keep the MediaSender's audio task active
+                await super().process_frame(silent_frame, FrameDirection.DOWNSTREAM)
+                
+                frames_sent += 1
+                
+                # Log progress every second
+                if frames_sent % 50 == 0:  # 50 frames = 1 second at 20ms/frame
+                    elapsed = time.time() - start_time
+                    logger.debug(f"🔇 Silent frames progress: {frames_sent}/{num_frames} frames sent, {elapsed:.3f}s elapsed")
+                
+                # Wait for next frame timing
+                await asyncio.sleep(frame_duration)
+            
+            total_time = time.time() - start_time
+            logger.info(f"✅ Finished sending {frames_sent} silent frames over {total_time:.3f}s")
+            
+        except asyncio.CancelledError:
+            logger.info(f"🚫 Silent frames task cancelled after {frames_sent} frames")
+            raise
+        except Exception as e:
+            logger.error(f"❌ Error in silent frames task: {e}")
+        finally:
+            # Reset audio tracking
+            self._audio_start_time = None
+            self._total_audio_samples = 0
+            logger.debug("🔄 Reset audio duration tracking")
     
     async def cancel(self, frame: CancelFrame):
         """Handle cancellation/interruption."""
@@ -248,6 +358,11 @@ class MentraOSOutputTransport(BaseOutputTransport):
         
         # Reset TTS state
         self._tts_active = False
+        
+        # Cancel silent frames task if running
+        if self._silent_frames_task and not self._silent_frames_task.done():
+            self._silent_frames_task.cancel()
+            logger.debug("🚫 Cancelled silent frames task on interruption")
         
         # Finalize any active stream on interruption
         if self._current_tts_filename:

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,6 +1,6 @@
-fastapi==0.110.2
-uvicorn[standard]==0.29.0
-websockets==12.0
-loguru==0.7.2
-python-dotenv==1.0.0
-pipecat-ai[webrtc,daily,silero,openai,deepgram,cartesia]
+pipecat-ai[webrtc,daily,silero,openai,deepgram,cartesia]===0.0.76
+python-dotenv
+fastapi
+uvicorn
+
+

--- a/python/test_mentraos_bot.py
+++ b/python/test_mentraos_bot.py
@@ -116,6 +116,7 @@ async def run_bot(
             api_key=mentra_api_key,
             package_name=package_name,
             vad_analyzer=SileroVADAnalyzer(),
+            bot_stopped_speaking_delay=2.5,  # MentraOS requires ~2.5s to start audio playback
         )
 
         # Set up LLM with initial system message

--- a/python/test_mentraos_bot.py
+++ b/python/test_mentraos_bot.py
@@ -21,11 +21,11 @@ from pipecat.pipeline.task import PipelineTask, PipelineParams
 from pipecat.processors.frame_processor import FrameDirection, FrameProcessor
 from pipecat.services.deepgram.stt import DeepgramSTTService
 from pipecat.services.openai import OpenAILLMService
+from pipecat.services.cartesia.tts import CartesiaTTSService
 from pipecat.processors.aggregators.openai_llm_context import (
     OpenAILLMContext,
     OpenAILLMContextFrame,
 )
-from pipecat.processors.aggregators.llm_response import LLMAssistantAggregatorParams
 
 
 # Add parent directory to path to import mentraos module
@@ -39,7 +39,8 @@ load_dotenv()
 
 # Configure logger
 logger.remove()
-logger.add(sys.stderr, level="TRACE")
+# logger.add(sys.stderr, level="TRACE")
+logger.add(sys.stderr, level="DEBUG")
 
 
 class UserTranscriptionHandler(FrameProcessor):
@@ -77,9 +78,9 @@ class AssistantResponseHandler(FrameProcessor):
                 TextWallFrame(f"Assistant said: {last_message['content']}"), direction
             )
 
-            # Speak the assistant's response
-            if last_message.get("role") == "assistant" and last_message.get("content"):
-                await self._app_session.audio.speak(last_message["content"])
+            # Don't speak - the MentraOSOutputTransport will handle TTS audio
+            # if last_message.get("role") == "assistant" and last_message.get("content"):
+            #     await self._app_session.audio.speak(last_message["content"])
 
         await self.push_frame(frame, direction)
 
@@ -95,12 +96,16 @@ async def run_bot(
         # Get API keys
         deepgram_api_key = os.getenv("DEEPGRAM_API_KEY")
         openai_api_key = os.getenv("OPENAI_API_KEY")
+        cartesia_api_key = os.getenv("CARTESIA_API_KEY")
 
         if not deepgram_api_key:
             logger.error("❌ DEEPGRAM_API_KEY not set in environment")
             return
         if not openai_api_key:
             logger.error("❌ OPENAI_API_KEY not set in environment")
+            return
+        if not cartesia_api_key:
+            logger.error("❌ CARTESIA_API_KEY not set in environment")
             return
 
         # Create MentraOS transport
@@ -136,13 +141,18 @@ async def run_bot(
         ]
 
         llm = OpenAILLMService(api_key=openai_api_key)
+        tts = CartesiaTTSService(
+            api_key=cartesia_api_key,
+            voice_id="71a7ad14-091c-4e8e-a314-022ece01c121",  # British Reading Lady
+        )
         user_transcription_handler = UserTranscriptionHandler()
         # Create a placeholder for the handler - will set app_session after transport is ready
         assistant_response_handler = AssistantResponseHandler(None)
         context = OpenAILLMContext(messages)
         context_aggregator = llm.create_context_aggregator(
             context,
-            assistant_params=LLMAssistantAggregatorParams(expect_stripped_words=False),
+            # need to set expect_stripped_words if the assistant aggregator is before the transport output.
+            # assistant_params=LLMAssistantAggregatorParams(expect_stripped_words=False),
         )
 
         # Build pipeline
@@ -153,9 +163,10 @@ async def run_bot(
                 user_transcription_handler,
                 context_aggregator.user(),
                 llm,
+                tts,
+                transport.output(),
                 context_aggregator.assistant(),
                 assistant_response_handler,
-                transport.output(),
             ]
         )
 
@@ -175,16 +186,18 @@ async def run_bot(
             logger.info("🎉 Client connected to MentraOS")
             # Set the app_session on the assistant response handler
             assistant_response_handler._app_session = app_session
-            
+
             # Register audio play response handler
             @app_session.events.on_audio_play_response
             async def handle_audio_response(event):
-                logger.info(f"🔊 AUDIO RESPONSE EVENT: requestId={event.request_id}, success={event.success}")
+                logger.info(
+                    f"🔊 AUDIO RESPONSE EVENT: requestId={event.request_id}, success={event.success}"
+                )
                 if not event.success and event.error:
                     logger.error(f"  Error: {event.error}")
-            
-            # Initialize the conversation context
-            await task.queue_frames([context_aggregator.user().get_context_frame()])
+
+            # Don't send initial context frame - wait for user to speak first
+            # await task.queue_frames([context_aggregator.user().get_context_frame()])
 
         logger.info(f"🎯 Pipeline running for session {session_id}")
         runner = PipelineRunner(handle_sigint=True)


### PR DESCRIPTION
Stream audio from the Pipecat pipeline to the app by saving audio output in an mp3 file and serving the file from an app HTTP endpoint.

We send the MentraOS play_audio request as soon as we have written the first chunk into the file. When the MentraOS cloud requests the file, we serve the bytes we have available and keep the HTTP request open, serving bytes as they are written, until the TTS generation is complete. 
